### PR TITLE
Add object widget dependency and update image handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
     "@eeacms/volto-listing-block",
     "@eeacms/volto-eea-design-system",
     "@eeacms/volto-eea-website-theme",
-    "@eeacms/volto-spotlight"
+    "@eeacms/volto-spotlight",
+    "@eeacms/volto-object-widget"
   ],
   "dependencies": {
     "@eeacms/volto-eea-design-system": "^1.31.1",
     "@eeacms/volto-eea-website-theme": "*",
     "@eeacms/volto-hero-block": "*",
     "@eeacms/volto-listing-block": "*",
-    "@eeacms/volto-spotlight": "*"
+    "@eeacms/volto-spotlight": "*",
+    "@eeacms/volto-object-widget": "eea/volto-object-widget#develop"
   },
   "repository": {
     "type": "git",

--- a/src/components/manage/Blocks/Hero/HeroEdit.jsx
+++ b/src/components/manage/Blocks/Hero/HeroEdit.jsx
@@ -1,29 +1,29 @@
-import React, { useCallback, useMemo } from "react";
-import { connect } from "react-redux";
-import { compose } from "redux";
-import isFunction from "lodash/isFunction";
-import config from "@plone/volto/registry";
-import { BlockDataForm, SidebarPortal } from "@plone/volto/components";
-import { BodyClass } from "@plone/volto/helpers";
-import SlateEditor from "@plone/volto-slate/editor/SlateEditor";
-import { handleKey } from "@plone/volto-slate/blocks/Text/keyboard";
+import React, { useCallback, useMemo } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import isFunction from 'lodash/isFunction';
+import config from '@plone/volto/registry';
+import { BlockDataForm, SidebarPortal } from '@plone/volto/components';
+import { BodyClass } from '@plone/volto/helpers';
+import SlateEditor from '@plone/volto-slate/editor/SlateEditor';
+import { handleKey } from '@plone/volto-slate/blocks/Text/keyboard';
 import {
   uploadContent,
   saveSlateBlockSelection,
-} from "@plone/volto-slate/actions";
+} from '@plone/volto-slate/actions';
 
-import { defineMessages, injectIntl } from "react-intl";
-import { createSlateHeader } from "@eeacms/volto-hero-block/helpers";
-import Hero from "@eeacms/volto-hero-block/components/Blocks/Hero/Hero";
-import Banner from "@eeacms/volto-eea-design-system/ui/Banner/Banner";
-import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
-import HeroMetadata from "./HeroMetadata";
-import HeroCopyright from "./HeroCopyright";
+import { defineMessages, injectIntl } from 'react-intl';
+import { createSlateHeader } from '@eeacms/volto-hero-block/helpers';
+import Hero from '@eeacms/volto-hero-block/components/Blocks/Hero/Hero';
+import Banner from '@eeacms/volto-eea-design-system/ui/Banner/Banner';
+import { getImageScaleParams } from '@eeacms/volto-object-widget/helpers';
+import HeroMetadata from './HeroMetadata';
+import HeroCopyright from './HeroCopyright';
 
 const messages = defineMessages({
   published: {
-    id: "Published",
-    defaultMessage: "Published",
+    id: 'Published',
+    defaultMessage: 'Published',
   },
 });
 
@@ -42,8 +42,8 @@ const Edit = (props) => {
   const metadata = props.metadata || props.properties;
   const { hidePublishingDate } = props.data;
   const { text, copyright, copyrightIcon, copyrightPosition } = data;
-  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || "";
-  const heroImage = getImageScaleParams(data.image, "large");
+  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || '';
+  const heroImage = getImageScaleParams(data.image, 'large');
   const schema = React.useMemo(() => {
     const blockSchema = config.blocks.blocksConfig.hero.schema;
     if (isFunction(blockSchema)) {
@@ -61,7 +61,7 @@ const Edit = (props) => {
   );
 
   const publishingDate = useMemo(
-    () => getDate(hidePublishingDate, "effective"),
+    () => getDate(hidePublishingDate, 'effective'),
     [getDate, hidePublishingDate],
   );
 
@@ -82,7 +82,12 @@ const Edit = (props) => {
   return (
     <>
       <BodyClass className="with-hero-block" />
-      <Hero {...data} image={heroImage?.download} height={heroImage?.height}>
+      <Hero
+        {...data}
+        image={data.image}
+        image_url={heroImage?.download}
+        height={heroImage?.height}
+      >
         <Hero.Text {...data}>
           <SlateEditor
             index={index}

--- a/src/components/manage/Blocks/Hero/HeroEdit.jsx
+++ b/src/components/manage/Blocks/Hero/HeroEdit.jsx
@@ -1,28 +1,29 @@
-import React, { useCallback, useMemo } from 'react';
-import { connect } from 'react-redux';
-import { compose } from 'redux';
-import isFunction from 'lodash/isFunction';
-import config from '@plone/volto/registry';
-import { BlockDataForm, SidebarPortal } from '@plone/volto/components';
-import { BodyClass } from '@plone/volto/helpers';
-import SlateEditor from '@plone/volto-slate/editor/SlateEditor';
-import { handleKey } from '@plone/volto-slate/blocks/Text/keyboard';
+import React, { useCallback, useMemo } from "react";
+import { connect } from "react-redux";
+import { compose } from "redux";
+import isFunction from "lodash/isFunction";
+import config from "@plone/volto/registry";
+import { BlockDataForm, SidebarPortal } from "@plone/volto/components";
+import { BodyClass } from "@plone/volto/helpers";
+import SlateEditor from "@plone/volto-slate/editor/SlateEditor";
+import { handleKey } from "@plone/volto-slate/blocks/Text/keyboard";
 import {
   uploadContent,
   saveSlateBlockSelection,
-} from '@plone/volto-slate/actions';
+} from "@plone/volto-slate/actions";
 
-import { defineMessages, injectIntl } from 'react-intl';
-import { createSlateHeader } from '@eeacms/volto-hero-block/helpers';
-import Hero from '@eeacms/volto-hero-block/components/Blocks/Hero/Hero';
-import Banner from '@eeacms/volto-eea-design-system/ui/Banner/Banner';
-import HeroMetadata from './HeroMetadata';
-import HeroCopyright from './HeroCopyright';
+import { defineMessages, injectIntl } from "react-intl";
+import { createSlateHeader } from "@eeacms/volto-hero-block/helpers";
+import Hero from "@eeacms/volto-hero-block/components/Blocks/Hero/Hero";
+import Banner from "@eeacms/volto-eea-design-system/ui/Banner/Banner";
+import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
+import HeroMetadata from "./HeroMetadata";
+import HeroCopyright from "./HeroCopyright";
 
 const messages = defineMessages({
   published: {
-    id: 'Published',
-    defaultMessage: 'Published',
+    id: "Published",
+    defaultMessage: "Published",
   },
 });
 
@@ -41,7 +42,8 @@ const Edit = (props) => {
   const metadata = props.metadata || props.properties;
   const { hidePublishingDate } = props.data;
   const { text, copyright, copyrightIcon, copyrightPosition } = data;
-  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || '';
+  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || "";
+  const heroImage = getImageScaleParams(data.image, "large");
   const schema = React.useMemo(() => {
     const blockSchema = config.blocks.blocksConfig.hero.schema;
     if (isFunction(blockSchema)) {
@@ -59,7 +61,7 @@ const Edit = (props) => {
   );
 
   const publishingDate = useMemo(
-    () => getDate(hidePublishingDate, 'effective'),
+    () => getDate(hidePublishingDate, "effective"),
     [getDate, hidePublishingDate],
   );
 
@@ -80,7 +82,7 @@ const Edit = (props) => {
   return (
     <>
       <BodyClass className="with-hero-block" />
-      <Hero {...data}>
+      <Hero {...data} image={heroImage?.download} height={heroImage?.height}>
         <Hero.Text {...data}>
           <SlateEditor
             index={index}

--- a/src/components/manage/Blocks/Hero/HeroView.jsx
+++ b/src/components/manage/Blocks/Hero/HeroView.jsx
@@ -1,27 +1,29 @@
-import React, { useCallback, useMemo } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
-import { compose } from 'redux';
-import { BodyClass } from '@plone/volto/helpers';
-import { serializeText } from '@eeacms/volto-hero-block/helpers';
-import Hero from '@eeacms/volto-hero-block/components/Blocks/Hero/Hero';
-import Banner from '@eeacms/volto-eea-design-system/ui/Banner/Banner';
-import config from '@plone/volto/registry';
-import HeroMetadata from './HeroMetadata';
-import HeroCopyright from './HeroCopyright';
+import React, { useCallback, useMemo } from "react";
+import { defineMessages, injectIntl } from "react-intl";
+import { compose } from "redux";
+import { BodyClass } from "@plone/volto/helpers";
+import { serializeText } from "@eeacms/volto-hero-block/helpers";
+import Hero from "@eeacms/volto-hero-block/components/Blocks/Hero/Hero";
+import Banner from "@eeacms/volto-eea-design-system/ui/Banner/Banner";
+import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
+import config from "@plone/volto/registry";
+import HeroMetadata from "./HeroMetadata";
+import HeroCopyright from "./HeroCopyright";
 
 const messages = defineMessages({
   published: {
-    id: 'Published',
-    defaultMessage: 'Published',
+    id: "Published",
+    defaultMessage: "Published",
   },
 });
 
 const View = (props) => {
   const { data = {}, intl } = props;
   const { text, copyright, copyrightIcon, copyrightPosition } = data;
-  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || '';
+  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || "";
   const metadata = props.metadata || props.properties;
   const { hidePublishingDate } = props.data;
+  const heroImage = getImageScaleParams(data.image, "large");
 
   // Set dates
   const getDate = useCallback(
@@ -32,14 +34,14 @@ const View = (props) => {
   );
 
   const publishingDate = useMemo(
-    () => getDate(hidePublishingDate, 'effective'),
+    () => getDate(hidePublishingDate, "effective"),
     [getDate, hidePublishingDate],
   );
 
   return (
     <React.Fragment>
       <BodyClass className="with-hero-block" />
-      <Hero {...data}>
+      <Hero {...data} image={heroImage?.download} height={heroImage?.height}>
         <Hero.Text {...data}>{serializeText(text)}</Hero.Text>
         <Hero.Meta>
           <Banner.MetadataField

--- a/src/components/manage/Blocks/Hero/HeroView.jsx
+++ b/src/components/manage/Blocks/Hero/HeroView.jsx
@@ -1,29 +1,29 @@
-import React, { useCallback, useMemo } from "react";
-import { defineMessages, injectIntl } from "react-intl";
-import { compose } from "redux";
-import { BodyClass } from "@plone/volto/helpers";
-import { serializeText } from "@eeacms/volto-hero-block/helpers";
-import Hero from "@eeacms/volto-hero-block/components/Blocks/Hero/Hero";
-import Banner from "@eeacms/volto-eea-design-system/ui/Banner/Banner";
-import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
-import config from "@plone/volto/registry";
-import HeroMetadata from "./HeroMetadata";
-import HeroCopyright from "./HeroCopyright";
+import React, { useCallback, useMemo } from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
+import { compose } from 'redux';
+import { BodyClass } from '@plone/volto/helpers';
+import { serializeText } from '@eeacms/volto-hero-block/helpers';
+import Hero from '@eeacms/volto-hero-block/components/Blocks/Hero/Hero';
+import Banner from '@eeacms/volto-eea-design-system/ui/Banner/Banner';
+import { getImageScaleParams } from '@eeacms/volto-object-widget/helpers';
+import config from '@plone/volto/registry';
+import HeroMetadata from './HeroMetadata';
+import HeroCopyright from './HeroCopyright';
 
 const messages = defineMessages({
   published: {
-    id: "Published",
-    defaultMessage: "Published",
+    id: 'Published',
+    defaultMessage: 'Published',
   },
 });
 
 const View = (props) => {
   const { data = {}, intl } = props;
   const { text, copyright, copyrightIcon, copyrightPosition } = data;
-  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || "";
+  const copyrightPrefix = config.blocks.blocksConfig.hero.copyrightPrefix || '';
   const metadata = props.metadata || props.properties;
   const { hidePublishingDate } = props.data;
-  const heroImage = getImageScaleParams(data.image, "large");
+  const heroImage = getImageScaleParams(data.image, 'large');
 
   // Set dates
   const getDate = useCallback(
@@ -34,14 +34,19 @@ const View = (props) => {
   );
 
   const publishingDate = useMemo(
-    () => getDate(hidePublishingDate, "effective"),
+    () => getDate(hidePublishingDate, 'effective'),
     [getDate, hidePublishingDate],
   );
 
   return (
     <React.Fragment>
       <BodyClass className="with-hero-block" />
-      <Hero {...data} image={heroImage?.download} height={heroImage?.height}>
+      <Hero
+        {...data}
+        image={data.image}
+        image_url={heroImage?.download}
+        height={heroImage?.height}
+      >
         <Hero.Text {...data}>{serializeText(text)}</Hero.Text>
         <Hero.Meta>
           <Banner.MetadataField

--- a/src/customizations/volto/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
+++ b/src/customizations/volto/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
@@ -1,6 +1,5 @@
-import { toPublicURL, Helmet } from "@plone/volto/helpers";
-import config from "@plone/volto/registry";
-import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
+import { toPublicURL, Helmet } from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
 
 const ContentMetadataTags = (props) => {
   const {
@@ -32,27 +31,25 @@ const ContentMetadataTags = (props) => {
       image = image_field;
     }
 
-    const imageInfo = getImageScaleParams(image, "large");
-    const ogImageInfo = getImageScaleParams(opengraph_image, "large");
-
     const contentImageInfo = {
-      contentHasImage: !!imageInfo?.download,
+      contentHasImage: false,
       url: null,
       height: null,
       width: null,
       alt: null,
     };
+    contentImageInfo.contentHasImage = image?.scales?.large?.download || false;
 
-    if (contentImageInfo.contentHasImage && ogImageInfo) {
-      contentImageInfo.url = ogImageInfo.download;
-      contentImageInfo.height = ogImageInfo.height;
-      contentImageInfo.width = ogImageInfo.width;
-      contentImageInfo.alt = opengraph_image?.alt || title || "Image";
+    if (contentImageInfo.contentHasImage && opengraph_image?.scales?.large) {
+      contentImageInfo.url = opengraph_image.scales.large.download;
+      contentImageInfo.height = opengraph_image.scales.large.height;
+      contentImageInfo.width = opengraph_image.scales.large.width;
+      contentImageInfo.alt = opengraph_image.alt || title || 'Image';
     } else if (contentImageInfo.contentHasImage) {
-      contentImageInfo.url = toPublicURL(imageInfo.download);
-      contentImageInfo.height = imageInfo.height;
-      contentImageInfo.width = imageInfo.width;
-      contentImageInfo.alt = image?.alt || title || "Image";
+      contentImageInfo.url = toPublicURL(image.scales.large.download);
+      contentImageInfo.height = image.scales.large.height;
+      contentImageInfo.width = image.scales.large.width;
+      contentImageInfo.alt = image.alt || title || 'Image';
     }
 
     return contentImageInfo;
@@ -62,10 +59,10 @@ const ContentMetadataTags = (props) => {
 
   return (
     <Helmet>
-      <title>{(seo_title || title)?.replace(/\u00AD/g, "")}</title>
+      <title>{(seo_title || title)?.replace(/\u00AD/g, '')}</title>
       <link
         rel="canonical"
-        href={seo_canonical_url || toPublicURL(props.content["@id"])}
+        href={seo_canonical_url || toPublicURL(props.content['@id'])}
       />
       <meta name="description" content={seo_description || description} />
       <meta
@@ -75,7 +72,7 @@ const ContentMetadataTags = (props) => {
       <meta property="og:type" content="website" />
       <meta
         property="og:url"
-        content={seo_canonical_url || toPublicURL(props.content["@id"])}
+        content={seo_canonical_url || toPublicURL(props.content['@id'])}
       />
       {seo_noindex && <meta name="robots" content="noindex" />}
       {contentImageInfo.contentHasImage && (
@@ -114,7 +111,7 @@ const ContentMetadataTags = (props) => {
       <meta name="twitter:card" content="summary_large_image" />
       <meta
         property="twitter:url"
-        content={seo_canonical_url || toPublicURL(props.content["@id"])}
+        content={seo_canonical_url || toPublicURL(props.content['@id'])}
       />
       {/* TODO: Improve SEO backend metadata providers by adding the twitter handler */}
       {/* <meta property="twitter:site" content={'@my_twitter_handler'} /> */}

--- a/src/customizations/volto/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
+++ b/src/customizations/volto/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
@@ -1,5 +1,6 @@
-import { toPublicURL, Helmet } from '@plone/volto/helpers';
-import config from '@plone/volto/registry';
+import { toPublicURL, Helmet } from "@plone/volto/helpers";
+import config from "@plone/volto/registry";
+import { getImageScaleParams } from "@eeacms/volto-object-widget/helpers";
 
 const ContentMetadataTags = (props) => {
   const {
@@ -31,25 +32,27 @@ const ContentMetadataTags = (props) => {
       image = image_field;
     }
 
+    const imageInfo = getImageScaleParams(image, "large");
+    const ogImageInfo = getImageScaleParams(opengraph_image, "large");
+
     const contentImageInfo = {
-      contentHasImage: false,
+      contentHasImage: !!imageInfo?.download,
       url: null,
       height: null,
       width: null,
       alt: null,
     };
-    contentImageInfo.contentHasImage = image?.scales?.large?.download || false;
 
-    if (contentImageInfo.contentHasImage && opengraph_image?.scales?.large) {
-      contentImageInfo.url = opengraph_image.scales.large.download;
-      contentImageInfo.height = opengraph_image.scales.large.height;
-      contentImageInfo.width = opengraph_image.scales.large.width;
-      contentImageInfo.alt = opengraph_image.alt || title || 'Image';
+    if (contentImageInfo.contentHasImage && ogImageInfo) {
+      contentImageInfo.url = ogImageInfo.download;
+      contentImageInfo.height = ogImageInfo.height;
+      contentImageInfo.width = ogImageInfo.width;
+      contentImageInfo.alt = opengraph_image?.alt || title || "Image";
     } else if (contentImageInfo.contentHasImage) {
-      contentImageInfo.url = toPublicURL(image.scales.large.download);
-      contentImageInfo.height = image.scales.large.height;
-      contentImageInfo.width = image.scales.large.width;
-      contentImageInfo.alt = image.alt || title || 'Image';
+      contentImageInfo.url = toPublicURL(imageInfo.download);
+      contentImageInfo.height = imageInfo.height;
+      contentImageInfo.width = imageInfo.width;
+      contentImageInfo.alt = image?.alt || title || "Image";
     }
 
     return contentImageInfo;
@@ -59,10 +62,10 @@ const ContentMetadataTags = (props) => {
 
   return (
     <Helmet>
-      <title>{(seo_title || title)?.replace(/\u00AD/g, '')}</title>
+      <title>{(seo_title || title)?.replace(/\u00AD/g, "")}</title>
       <link
         rel="canonical"
-        href={seo_canonical_url || toPublicURL(props.content['@id'])}
+        href={seo_canonical_url || toPublicURL(props.content["@id"])}
       />
       <meta name="description" content={seo_description || description} />
       <meta
@@ -72,7 +75,7 @@ const ContentMetadataTags = (props) => {
       <meta property="og:type" content="website" />
       <meta
         property="og:url"
-        content={seo_canonical_url || toPublicURL(props.content['@id'])}
+        content={seo_canonical_url || toPublicURL(props.content["@id"])}
       />
       {seo_noindex && <meta name="robots" content="noindex" />}
       {contentImageInfo.contentHasImage && (
@@ -111,7 +114,7 @@ const ContentMetadataTags = (props) => {
       <meta name="twitter:card" content="summary_large_image" />
       <meta
         property="twitter:url"
-        content={seo_canonical_url || toPublicURL(props.content['@id'])}
+        content={seo_canonical_url || toPublicURL(props.content["@id"])}
       />
       {/* TODO: Improve SEO backend metadata providers by adding the twitter handler */}
       {/* <meta property="twitter:site" content={'@my_twitter_handler'} /> */}


### PR DESCRIPTION
## Summary
- add `@eeacms/volto-object-widget` addon dependency
- compute hero image URL via `getImageScaleParams`
- use `getImageScaleParams` for SEO metadata image tags

## Testing
- `make lint` *(fails: `eslin` not found)*
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859962b503c83259acf4029985fa2d8